### PR TITLE
Add core models and progression managers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.build
+.DS_Store

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "PuttingGameCore",
+    platforms: [
+        .iOS(.v17)
+    ],
+    products: [
+        .library(name: "PuttingGameCore", targets: ["PuttingGameCore"])
+    ],
+    targets: [
+        .target(name: "PuttingGameCore", path: "Sources/PuttingGameCore"),
+        .testTarget(name: "PuttingGameCoreTests", dependencies: ["PuttingGameCore"], path: "Tests/PuttingGameCoreTests")
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# PuttingGameCore
+
+This package provides core models and progression managers for the Putting XP concept. It contains:
+
+- Data models for shots, sessions and profiles.
+- `XPManager` to calculate XP based on made putts.
+- `LevelManager` with a simple XP table.
+- `BadgeManager` that detects a few sample badges.
+
+The package builds on Swift 6.1 and includes unit tests validating XP totals, level calculation and badge unlocking.
+
+## Running Tests
+
+```
+swift test
+```
+

--- a/Sources/PuttingGameCore/BadgeManager.swift
+++ b/Sources/PuttingGameCore/BadgeManager.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+public struct BadgeManager {
+    public init() {}
+
+    public func earnedBadges(forSession session: Session) -> [BadgeID] {
+        var earned: [BadgeID] = []
+        let makesByDistance = Dictionary(grouping: session.shots.filter { $0.result }, by: { $0.distanceFt })
+        if let shortMakes = makesByDistance[3], shortMakes.count >= 10 {
+            earned.append(.iceCold)
+        }
+        if let longMakes = makesByDistance[8], longMakes.count >= 5 {
+            earned.append(.clutch)
+        }
+        let ladderCounts = session.shots.filter { $0.result }.count
+        if ladderCounts >= 6 {
+            earned.append(.ladderMaster)
+        }
+        return earned
+    }
+}

--- a/Sources/PuttingGameCore/LevelManager.swift
+++ b/Sources/PuttingGameCore/LevelManager.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+public struct LevelManager {
+    public let xpTable: [Int]
+    public init(xpTable: [Int] = [0, 100, 250, 450, 700, 1000]) {
+        self.xpTable = xpTable
+    }
+
+    public func level(forXP xp: Int) -> Int {
+        var level = 1
+        for (idx, threshold) in xpTable.enumerated() where xp >= threshold {
+            level = idx + 1
+        }
+        return level
+    }
+
+    public func xpNeeded(forLevel level: Int) -> Int {
+        guard level - 1 < xpTable.count else { return xpTable.last ?? 0 }
+        return xpTable[level - 1]
+    }
+}

--- a/Sources/PuttingGameCore/Models.swift
+++ b/Sources/PuttingGameCore/Models.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+public struct Shot: Codable, Sendable, Equatable {
+    public var date: Date
+    public var distanceFt: Int
+    public var breakType: BreakType
+    public var greenSpeed: GreenSpeed
+    public var result: Bool
+
+    public init(date: Date = .now, distanceFt: Int, breakType: BreakType, greenSpeed: GreenSpeed, result: Bool) {
+        self.date = date
+        self.distanceFt = distanceFt
+        self.breakType = breakType
+        self.greenSpeed = greenSpeed
+        self.result = result
+    }
+}
+
+public enum BreakType: String, Codable, Sendable, CaseIterable { case straight, left, right }
+public enum GreenSpeed: String, Codable, Sendable, CaseIterable { case slow, medium, fast }
+
+public struct Session: Codable, Sendable, Identifiable {
+    public var id: UUID
+    public var start: Date
+    public var end: Date
+    public var shots: [Shot]
+    public var notes: String?
+
+    public init(id: UUID = UUID(), start: Date = .now, end: Date = .now, shots: [Shot] = [], notes: String? = nil) {
+        self.id = id
+        self.start = start
+        self.end = end
+        self.shots = shots
+        self.notes = notes
+    }
+}
+
+public struct ChallengeRun: Codable, Sendable, Identifiable {
+    public var id: UUID
+    public var type: String
+    public var params: [String: Int]
+    public var resultSummary: String
+
+    public init(id: UUID = UUID(), type: String, params: [String: Int] = [:], resultSummary: String = "") {
+        self.id = id
+        self.type = type
+        self.params = params
+        self.resultSummary = resultSummary
+    }
+}
+
+public struct Profile: Codable, Sendable {
+    public var level: Int
+    public var xp: Int
+    public var badges: Set<BadgeID>
+    public var streakDays: Int
+    public var bests: [Int: Int]
+
+    public init(level: Int = 1, xp: Int = 0, badges: Set<BadgeID> = [], streakDays: Int = 0, bests: [Int: Int] = [:]) {
+        self.level = level
+        self.xp = xp
+        self.badges = badges
+        self.streakDays = streakDays
+        self.bests = bests
+    }
+}
+
+public enum BadgeID: String, Codable, Sendable, CaseIterable {
+    case iceCold, clutch, ladderMaster, speedDemon, consistency, leftBreakTamer
+}

--- a/Sources/PuttingGameCore/Theme.swift
+++ b/Sources/PuttingGameCore/Theme.swift
@@ -1,0 +1,11 @@
+#if canImport(SwiftUI)
+import SwiftUI
+
+public struct Theme {
+    public static let deepGreen = Color(red: 0x0C/255, green: 0x3B/255, blue: 0x2E/255)
+    public static let neonLime = Color(red: 0xB8/255, green: 0xFF/255, blue: 0x5E/255)
+    public static let goldAccent = Color(red: 0xE6/255, green: 0xC1/255, blue: 0x4E/255)
+    public static let cream = Color(red: 0xFA/255, green: 0xF9/255, blue: 0xF6/255)
+    public static let charcoal = Color(red: 0x1F/255, green: 0x1F/255, blue: 0x1F/255)
+}
+#endif

--- a/Sources/PuttingGameCore/XPManager.swift
+++ b/Sources/PuttingGameCore/XPManager.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public struct XPManager {
+    public func xpForShot(_ shot: Shot) -> Int {
+        // simple distance scaled: distance * 10 for make, 0 otherwise
+        guard shot.result else { return 0 }
+        return shot.distanceFt * 10
+    }
+
+    public func totalXP(forSession session: Session) -> Int {
+        session.shots.reduce(0) { $0 + xpForShot($1) }
+    }
+}

--- a/Tests/PuttingGameCoreTests/XPLevelTests.swift
+++ b/Tests/PuttingGameCoreTests/XPLevelTests.swift
@@ -1,0 +1,29 @@
+import Testing
+@testable import PuttingGameCore
+
+struct XPLevelTests {
+    @Test func levelProgression() throws {
+        let levelManager = LevelManager(xpTable: [0,100,300])
+        #expect(levelManager.level(forXP: 0) == 1)
+        #expect(levelManager.level(forXP: 100) == 2)
+        #expect(levelManager.level(forXP: 250) == 2)
+        #expect(levelManager.level(forXP: 400) == 3)
+    }
+
+    @Test func sessionXP() throws {
+        let shots = [Shot(distanceFt: 3, breakType: .straight, greenSpeed: .medium, result: true),
+                     Shot(distanceFt: 5, breakType: .left, greenSpeed: .medium, result: false),
+                     Shot(distanceFt: 8, breakType: .right, greenSpeed: .fast, result: true)]
+        let session = Session(shots: shots)
+        let xp = XPManager().totalXP(forSession: session)
+        #expect(xp == 110)
+    }
+
+    @Test func badgesEarned() throws {
+        var shots: [Shot] = []
+        for _ in 0..<10 { shots.append(Shot(distanceFt: 3, breakType: .straight, greenSpeed: .medium, result: true)) }
+        let session = Session(shots: shots)
+        let badges = BadgeManager().earnedBadges(forSession: session)
+        #expect(badges.contains(.iceCold))
+    }
+}


### PR DESCRIPTION
## Summary
- Define core data models for shots, sessions, challenges and profiles
- Implement XP, level and badge managers
- Provide sample palette and add Swift Package with unit tests

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68b9fb84408c832b84254f8e78e8ca5d