### PR TITLE
Add insight engine with ladder drill recommendation

### DIFF
--- a/Sources/PuttingGameCore/InsightEngine.swift
+++ b/Sources/PuttingGameCore/InsightEngine.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+public enum Insight: Equatable {
+    case none
+    case ladder(distance: Int)
+}
+
+public struct InsightEngine {
+    public init() {}
+
+    public func insight(for session: Session) -> Insight {
+        // group shots by distance
+        let grouped = Dictionary(grouping: session.shots, by: { $0.distanceFt })
+        // compute attempts and accuracy for each distance
+        var stats: [(distance: Int, attempts: Int, accuracy: Double)] = []
+        for (distance, shots) in grouped {
+            let attempts = shots.count
+            guard attempts >= 20 else { continue }
+            let makes = shots.filter { $0.result }.count
+            let accuracy = attempts > 0 ? Double(makes) / Double(attempts) : 0
+            stats.append((distance, attempts, accuracy))
+        }
+        guard !stats.isEmpty else { return .none }
+        // determine 25th percentile accuracy
+        let accuracies = stats.map { $0.accuracy }.sorted()
+        let idx = Int(Double(accuracies.count - 1) * 0.25)
+        let threshold = accuracies[idx]
+        // find first distance with accuracy <= threshold
+        if let target = stats.first(where: { $0.accuracy <= threshold }) {
+            return .ladder(distance: target.distance)
+        }
+        return .none
+    }
+}
+

--- a/Tests/PuttingGameCoreTests/InsightEngineTests.swift
+++ b/Tests/PuttingGameCoreTests/InsightEngineTests.swift
@@ -1,0 +1,48 @@
+import Testing
+@testable import PuttingGameCore
+
+struct InsightEngineTests {
+    @Test func ladderRecommendation() throws {
+        var shots: [Shot] = []
+        // 5ft distance: 20 attempts, 5 makes (25% accuracy)
+        for i in 0..<20 {
+            shots.append(Shot(distanceFt: 5, breakType: .straight, greenSpeed: .medium, result: i < 5))
+        }
+        // 3ft distance: 20 attempts, 15 makes (75% accuracy)
+        for i in 0..<20 {
+            shots.append(Shot(distanceFt: 3, breakType: .straight, greenSpeed: .medium, result: i < 15))
+        }
+        // 7ft distance: 20 attempts, 10 makes (50% accuracy)
+        for i in 0..<20 {
+            shots.append(Shot(distanceFt: 7, breakType: .straight, greenSpeed: .medium, result: i < 10))
+        }
+        let session = Session(shots: shots)
+        let engine = InsightEngine()
+        #expect(engine.insight(for: session) == .ladder(distance: 5))
+    }
+
+    @Test func onlyOneTipProduced() throws {
+        var shots: [Shot] = []
+        // distance 5ft low accuracy
+        for i in 0..<20 {
+            shots.append(Shot(distanceFt: 5, breakType: .straight, greenSpeed: .medium, result: i < 5))
+        }
+        // distance 6ft even lower accuracy
+        for i in 0..<20 {
+            shots.append(Shot(distanceFt: 6, breakType: .straight, greenSpeed: .medium, result: i < 4))
+        }
+        // distance 3ft high accuracy
+        for i in 0..<20 {
+            shots.append(Shot(distanceFt: 3, breakType: .straight, greenSpeed: .medium, result: i < 15))
+        }
+        let session = Session(shots: shots)
+        let engine = InsightEngine()
+        let insight = engine.insight(for: session)
+        switch insight {
+        case .ladder(let d):
+            #expect([5,6].contains(d))
+        case .none:
+            Issue.record("Expected a ladder insight")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `InsightEngine` to suggest ladder drill when attempts >= 20 and accuracy is in bottom quartile for a distance
- ensure only a single insight is returned per session
- test ladder recommendation logic and single-tip behavior

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68ba05706f48832b91ece3e545968fab