### PR TITLE
Add theme tokens with runtime switching and low-effects mode

### DIFF
--- a/PuttingGameV1/ContentView.swift
+++ b/PuttingGameV1/ContentView.swift
@@ -6,19 +6,35 @@
 //
 
 import SwiftUI
+import PuttingGameCore
 
 struct ContentView: View {
+    @EnvironmentObject var themeManager: ThemeManager
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        NavigationStack {
+            VStack {
+                Text("Hello, world!")
+                    .foregroundColor(themeManager.theme.colors.text)
+                    .padding(themeManager.theme.radii.medium)
+                    .background(themeManager.theme.colors.foreground)
+                    .cornerRadius(themeManager.theme.radii.small)
+                    .shadow(color: themeManager.theme.shadows.standard.color,
+                            radius: themeManager.theme.shadows.standard.radius,
+                            x: themeManager.theme.shadows.standard.x,
+                            y: themeManager.theme.shadows.standard.y)
+
+                NavigationLink("Settings") {
+                    SettingsView()
+                }
+                .padding(.top)
+            }
+            .padding()
+            .background(themeManager.theme.gradients.background)
         }
-        .padding()
     }
 }
 
 #Preview {
-    ContentView()
+    ContentView().environmentObject(ThemeManager())
 }

--- a/PuttingGameV1/PuttingGameV1App.swift
+++ b/PuttingGameV1/PuttingGameV1App.swift
@@ -6,12 +6,16 @@
 //
 
 import SwiftUI
+import PuttingGameCore
 
 @main
 struct PuttingGameV1App: App {
+    @StateObject private var themeManager = ThemeManager()
+
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .environmentObject(themeManager)
         }
     }
 }

--- a/PuttingGameV1/SettingsView.swift
+++ b/PuttingGameV1/SettingsView.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+import PuttingGameCore
+
+struct SettingsView: View {
+    @EnvironmentObject var themeManager: ThemeManager
+
+    var body: some View {
+        Form {
+            Picker("Theme", selection: $themeManager.selectedTheme) {
+                ForEach(ThemeKind.allCases) { kind in
+                    Text(kind.rawValue).tag(kind)
+                }
+            }
+            Toggle("Low Effects Mode", isOn: $themeManager.lowEffectsEnabled)
+        }
+        .navigationTitle("Settings")
+    }
+}
+
+#Preview {
+    SettingsView().environmentObject(ThemeManager())
+}

--- a/Sources/PuttingGameCore/Theme.swift
+++ b/Sources/PuttingGameCore/Theme.swift
@@ -1,11 +1,92 @@
 #if canImport(SwiftUI)
 import SwiftUI
 
-public struct Theme {
-    public static let deepGreen = Color(red: 0x0C/255, green: 0x3B/255, blue: 0x2E/255)
-    public static let neonLime = Color(red: 0xB8/255, green: 0xFF/255, blue: 0x5E/255)
-    public static let goldAccent = Color(red: 0xE6/255, green: 0xC1/255, blue: 0x4E/255)
-    public static let cream = Color(red: 0xFA/255, green: 0xF9/255, blue: 0xF6/255)
-    public static let charcoal = Color(red: 0x1F/255, green: 0x1F/255, blue: 0x1F/255)
+public struct Theme: Equatable {
+    public struct Colors {
+        public let background: Color
+        public let foreground: Color
+        public let accent: Color
+        public let text: Color
+    }
+    public struct Radii {
+        public let small: CGFloat
+        public let medium: CGFloat
+        public let large: CGFloat
+    }
+    public struct Shadow {
+        public let color: Color
+        public let radius: CGFloat
+        public let x: CGFloat
+        public let y: CGFloat
+    }
+    public struct Shadows {
+        public let standard: Shadow
+    }
+    public struct Gradients {
+        public let background: LinearGradient
+    }
+
+    public let colors: Colors
+    public let radii: Radii
+    public let shadows: Shadows
+    public let gradients: Gradients
+}
+
+public enum ThemeKind: String, CaseIterable, Identifiable {
+    case classic = "Classic"
+    case midnight = "Midnight"
+
+    public var id: String { rawValue }
+}
+
+public extension Theme {
+    static let classic = Theme(
+        colors: .init(
+            background: Color(red: 0xFA/255, green: 0xF9/255, blue: 0xF6/255),
+            foreground: Color(red: 0x0C/255, green: 0x3B/255, blue: 0x2E/255),
+            accent: Color(red: 0xB8/255, green: 0xFF/255, blue: 0x5E/255),
+            text: Color(red: 0x1F/255, green: 0x1F/255, blue: 0x1F/255)
+        ),
+        radii: .init(small: 4, medium: 8, large: 16),
+        shadows: .init(standard: .init(color: Color.black.opacity(0.2), radius: 4, x: 0, y: 2)),
+        gradients: .init(background: LinearGradient(
+            colors: [
+                Color(red: 0x0C/255, green: 0x3B/255, blue: 0x2E/255),
+                Color(red: 0xB8/255, green: 0xFF/255, blue: 0x5E/255)
+            ],
+            startPoint: .top,
+            endPoint: .bottom
+        ))
+    )
+
+    static let midnight = Theme(
+        colors: .init(
+            background: Color(red: 0x1F/255, green: 0x1F/255, blue: 0x1F/255),
+            foreground: Color(red: 0xFA/255, green: 0xF9/255, blue: 0xF6/255),
+            accent: Color(red: 0xE6/255, green: 0xC1/255, blue: 0x4E/255),
+            text: Color(red: 0xFA/255, green: 0xF9/255, blue: 0xF6/255)
+        ),
+        radii: .init(small: 4, medium: 8, large: 16),
+        shadows: .init(standard: .init(color: Color.black.opacity(0.8), radius: 4, x: 0, y: 2)),
+        gradients: .init(background: LinearGradient(
+            colors: [
+                Color.black,
+                Color(red: 0x0C/255, green: 0x3B/255, blue: 0x2E/255)
+            ],
+            startPoint: .top,
+            endPoint: .bottom
+        ))
+    )
+}
+
+public extension ThemeKind {
+    var theme: Theme {
+        switch self {
+        case .classic:
+            return .classic
+        case .midnight:
+            return .midnight
+        }
+    }
 }
 #endif

--- a/Sources/PuttingGameCore/ThemeManager.swift
+++ b/Sources/PuttingGameCore/ThemeManager.swift
@@ -1,0 +1,21 @@
+#if canImport(SwiftUI)
+import SwiftUI
+
+public final class ThemeManager: ObservableObject {
+    @Published public var selectedTheme: ThemeKind
+    @Published public var lowEffectsEnabled: Bool
+
+    public init(selectedTheme: ThemeKind = .classic, lowEffectsEnabled: Bool = false) {
+        self.selectedTheme = selectedTheme
+        self.lowEffectsEnabled = lowEffectsEnabled
+    }
+
+    public var theme: Theme {
+        selectedTheme.theme
+    }
+
+    public func adjustedBirthRate(_ base: CGFloat) -> CGFloat {
+        lowEffectsEnabled ? base * 0.5 : base
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- Expand theme into token-based model with classic and midnight variants
- Introduce ThemeManager for dynamic theme switching and optional low-effects mode
- Add Settings view to toggle themes and particle density at runtime

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68ba0571a974832b9fae128ee988b004