### PR TITLE
Add quest management system with SwiftUI view and tests

### DIFF
--- a/Sources/PuttingGameCore/QuestManager.swift
+++ b/Sources/PuttingGameCore/QuestManager.swift
@@ -1,0 +1,115 @@
+import Foundation
+#if canImport(Combine)
+import Combine
+#endif
+
+public struct Quest: Codable, Identifiable, Equatable {
+    public enum Frequency: String, Codable { case daily, weekly }
+    public var id: String
+    public var frequency: Frequency
+    public var title: String
+    public var start: Date
+    public var end: Date
+    public var progress: Int
+    public var goal: Int
+    public var reward: Int
+    public var claimed: Bool
+
+    public init(id: String = UUID().uuidString,
+                frequency: Frequency,
+                title: String,
+                start: Date,
+                end: Date,
+                progress: Int = 0,
+                goal: Int,
+                reward: Int,
+                claimed: Bool = false) {
+        self.id = id
+        self.frequency = frequency
+        self.title = title
+        self.start = start
+        self.end = end
+        self.progress = progress
+        self.goal = goal
+        self.reward = reward
+        self.claimed = claimed
+    }
+
+    public var isComplete: Bool { progress >= goal }
+    public var timeRemaining: TimeInterval { end.timeIntervalSinceNow }
+}
+
+// Protocol to allow conditional ObservableObject conformance
+#if canImport(Combine)
+public protocol QuestManagerBase: ObservableObject {}
+#else
+public protocol QuestManagerBase: AnyObject {}
+#endif
+
+public final class QuestManager: QuestManagerBase {
+    private let storageKey = "QuestManager.quests"
+    private let userDefaults: UserDefaults
+
+#if canImport(Combine)
+    @Published public private(set) var quests: [Quest] = []
+#else
+    public private(set) var quests: [Quest] = []
+#endif
+
+    public init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+        load()
+        refreshQuests()
+    }
+
+    public func refreshQuests(now: Date = .now) {
+        quests.removeAll { $0.end <= now }
+        let dailyCount = quests.filter { $0.frequency == .daily }.count
+        if dailyCount < 3 {
+            for _ in dailyCount..<3 { quests.append(makeQuest(frequency: .daily, start: now)) }
+        }
+        if !quests.contains(where: { $0.frequency == .weekly }) {
+            quests.append(makeQuest(frequency: .weekly, start: now))
+        }
+        save()
+    }
+
+    public func updateProgress(for questID: String, by amount: Int = 1) {
+        guard let idx = quests.firstIndex(where: { $0.id == questID }) else { return }
+        quests[idx].progress = min(quests[idx].progress + amount, quests[idx].goal)
+        save()
+    }
+
+    public func claimReward(for questID: String) -> Int? {
+        guard let idx = quests.firstIndex(where: { $0.id == questID }) else { return nil }
+        var quest = quests[idx]
+        guard quest.isComplete && !quest.claimed else { return nil }
+        quest.claimed = true
+        quests[idx] = quest
+        save()
+        return quest.reward
+    }
+
+    private func makeQuest(frequency: Quest.Frequency, start: Date) -> Quest {
+        let duration: TimeInterval = frequency == .daily ? 60*60*24 : 60*60*24*7
+        let end = start.addingTimeInterval(duration)
+        let goal = frequency == .daily ? 10 : 50
+        let reward = frequency == .daily ? 100 : 1000
+        let title = frequency == .daily ? "Sink \(goal) putts" : "Sink \(goal) putts this week"
+        return Quest(frequency: frequency, title: title, start: start, end: end, goal: goal, reward: reward)
+    }
+
+    private func load() {
+        guard let data = userDefaults.data(forKey: storageKey) else { return }
+        if let saved = try? JSONDecoder().decode([Quest].self, from: data) {
+            quests = saved
+        }
+    }
+
+    private func save() {
+        if let data = try? JSONEncoder().encode(quests) {
+            userDefaults.set(data, forKey: storageKey)
+        }
+    }
+}
+

--- a/Sources/PuttingGameCore/QuestView.swift
+++ b/Sources/PuttingGameCore/QuestView.swift
@@ -1,0 +1,37 @@
+#if canImport(SwiftUI)
+import SwiftUI
+
+public struct QuestView: View {
+    @ObservedObject var manager: QuestManager
+    @State private var now: Date = .now
+    private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
+
+    public init(manager: QuestManager) {
+        self.manager = manager
+    }
+
+    public var body: some View {
+        List {
+            ForEach(manager.quests) { quest in
+                VStack(alignment: .leading) {
+                    Text(quest.title)
+                    Text("Progress: \(quest.progress)/\(quest.goal)")
+                        .font(.subheadline)
+                    Text(timeRemaining(for: quest))
+                        .font(.caption)
+                }
+            }
+        }
+        .onReceive(timer) { now = $0 }
+    }
+
+    private func timeRemaining(for quest: Quest) -> String {
+        let remaining = quest.end.timeIntervalSince(now)
+        if remaining <= 0 { return "Expired" }
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.hour, .minute, .second]
+        formatter.unitsStyle = .short
+        return formatter.string(from: remaining) ?? "" 
+    }
+}
+#endif

--- a/Tests/PuttingGameCoreTests/QuestManagerTests.swift
+++ b/Tests/PuttingGameCoreTests/QuestManagerTests.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Testing
+@testable import PuttingGameCore
+
+struct QuestManagerTests {
+    @Test func generatesQuests() throws {
+        let defaults = UserDefaults(suiteName: "QuestManagerTests")!
+        defaults.removePersistentDomain(forName: "QuestManagerTests")
+        let manager = QuestManager(userDefaults: defaults)
+        let daily = manager.quests.filter { $0.frequency == .daily }
+        let weekly = manager.quests.filter { $0.frequency == .weekly }
+        #expect(daily.count == 3)
+        #expect(weekly.count == 1)
+    }
+
+    @Test func refreshReplacesExpired() throws {
+        let defaults = UserDefaults(suiteName: "QuestManagerTests2")!
+        defaults.removePersistentDomain(forName: "QuestManagerTests2")
+        let manager = QuestManager(userDefaults: defaults)
+        let previousDailyIDs = Set(manager.quests.filter { $0.frequency == .daily }.map { $0.id })
+        let weeklyID = manager.quests.first { $0.frequency == .weekly }!.id
+        let future = manager.quests.filter { $0.frequency == .daily }.first!.end.addingTimeInterval(1)
+        manager.refreshQuests(now: future)
+        let newDailyIDs = Set(manager.quests.filter { $0.frequency == .daily }.map { $0.id })
+        #expect(newDailyIDs.count == 3)
+        #expect(newDailyIDs.intersection(previousDailyIDs).isEmpty)
+        #expect(manager.quests.first { $0.frequency == .weekly }!.id == weeklyID)
+    }
+}


### PR DESCRIPTION
## Summary
- add `Quest` model and `QuestManager` with daily/weekly quests, persistence, and reward logic
- include SwiftUI `QuestView` to display quests with countdown timers
- test quest refresh and replacement logic

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68ba0573b168832bb39a9c8f951252c7