### PR TITLE
Persist and restore challenge sessions

### DIFF
--- a/PuttingGameV1/ContentView.swift
+++ b/PuttingGameV1/ContentView.swift
@@ -6,19 +6,53 @@
 //
 
 import SwiftUI
+import PuttingGameCore
 
 struct ContentView: View {
+    @ObservedObject var sessionStore: SessionStore
+    @State private var remaining: Int = 0
+    private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
+
     var body: some View {
         VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+            if sessionStore.activeSession != nil {
+                Text("Time remaining: \(remaining)")
+                    .accessibilityIdentifier("countdownLabel")
+            } else {
+                Button("Start Challenge") {
+                    startChallenge()
+                }
+                .accessibilityIdentifier("startButton")
+            }
         }
         .padding()
+        .onAppear {
+            updateRemaining()
+        }
+        .onReceive(timer) { _ in
+            updateRemaining()
+        }
+    }
+
+    private func startChallenge() {
+        sessionStore.activeSession = Session(start: .now, end: Date().addingTimeInterval(10))
+        updateRemaining()
+    }
+
+    private func updateRemaining() {
+        guard let session = sessionStore.activeSession else {
+            remaining = 0
+            return
+        }
+        remaining = max(0, Int(session.end.timeIntervalSinceNow.rounded()))
+        if remaining <= 0 {
+            sessionStore.activeSession = nil
+        } else {
+            sessionStore.save()
+        }
     }
 }
 
 #Preview {
-    ContentView()
+    ContentView(sessionStore: SessionStore())
 }

--- a/PuttingGameV1/PuttingGameV1App.swift
+++ b/PuttingGameV1/PuttingGameV1App.swift
@@ -9,9 +9,11 @@ import SwiftUI
 
 @main
 struct PuttingGameV1App: App {
+    @StateObject private var sessionStore = SessionStore()
+
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            ContentView(sessionStore: sessionStore)
         }
     }
 }

--- a/PuttingGameV1/SessionStore.swift
+++ b/PuttingGameV1/SessionStore.swift
@@ -1,0 +1,40 @@
+import Foundation
+import PuttingGameCore
+
+@MainActor
+final class SessionStore: ObservableObject {
+    @Published var activeSession: Session? {
+        didSet { save() }
+    }
+
+    private let url: URL
+
+    init(fileManager: FileManager = .default) {
+        url = fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("activeSession.json")
+        load()
+    }
+
+    func save() {
+        guard let session = activeSession else {
+            try? FileManager.default.removeItem(at: url)
+            return
+        }
+        do {
+            let data = try JSONEncoder().encode(session)
+            try data.write(to: url, options: .atomic)
+        } catch {
+            print("Failed to save session: \(error)")
+        }
+    }
+
+    func load() {
+        guard let data = try? Data(contentsOf: url),
+              let session = try? JSONDecoder().decode(Session.self, from: data),
+              session.end > .now else {
+            activeSession = nil
+            return
+        }
+        activeSession = session
+    }
+}

--- a/PuttingGameV1UITests/SessionRestorationUITests.swift
+++ b/PuttingGameV1UITests/SessionRestorationUITests.swift
@@ -1,0 +1,26 @@
+import XCTest
+
+final class SessionRestorationUITests: XCTestCase {
+    @MainActor
+    func testSessionPersistsAcrossLaunches() {
+        let app = XCUIApplication()
+        app.launch()
+
+        let startButton = app.buttons["startButton"]
+        XCTAssertTrue(startButton.waitForExistence(timeout: 2))
+        startButton.tap()
+
+        let countdownLabel = app.staticTexts["countdownLabel"]
+        XCTAssertTrue(countdownLabel.waitForExistence(timeout: 2))
+        sleep(1)
+        let valueBeforeKill = countdownLabel.label
+
+        app.terminate()
+        sleep(1)
+        app.launch()
+
+        let resumedLabel = app.staticTexts["countdownLabel"]
+        XCTAssertTrue(resumedLabel.waitForExistence(timeout: 2))
+        XCTAssertNotEqual(resumedLabel.label, valueBeforeKill)
+    }
+}


### PR DESCRIPTION
## Summary
- Save active challenge session data to disk and reload it on launch
- Resume a challenge countdown when relaunching the app
- Add UI test ensuring session state persists across app termination

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68ba05755884832b9527830fb620fd69