### PR TITLE
Add tip overlay with analytics after consecutive misses

### DIFF
--- a/PuttingGameV1/ContentView.swift
+++ b/PuttingGameV1/ContentView.swift
@@ -1,21 +1,37 @@
-//
-//  ContentView.swift
-//  PuttingGameV1
-//
-//  Created by Ethan Kobylinski on 7/6/25.
-//
-
 import SwiftUI
+import PuttingGameCore
 
+/// Simple interface to simulate practice putts and demonstrate tip overlays.
 struct ContentView: View {
+    @State private var session = PracticeSession()
+    @State private var distance: Double = 5
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        ZStack {
+            VStack(spacing: 24) {
+                Stepper("Distance: \(Int(distance)) ft", value: $distance, in: 1...60)
+                HStack {
+                    Button("Make") {
+                        session.recordPutt(distance: distance, made: true)
+                    }
+                    .buttonStyle(.borderedProminent)
+
+                    Button("Miss") {
+                        session.recordPutt(distance: distance, made: false)
+                    }
+                    .buttonStyle(.bordered)
+                }
+            }
+            .padding()
+
+            if let tip = session.activeTip {
+                TipOverlay(tip: tip) {
+                    session.dismissTip()
+                }
+                .transition(.opacity)
+            }
         }
-        .padding()
+        .animation(.default, value: session.activeTip)
     }
 }
 

--- a/PuttingGameV1/TipOverlay.swift
+++ b/PuttingGameV1/TipOverlay.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+/// A dismissible overlay displaying a practice tip for 5 seconds.
+struct TipOverlay: View {
+    let tip: String
+    let dismiss: () -> Void
+
+    @State private var isVisible = true
+
+    var body: some View {
+        if isVisible {
+            VStack {
+                Text(tip)
+                    .foregroundColor(.white)
+                    .padding()
+                    .background(Color.black.opacity(0.8))
+                    .cornerRadius(8)
+                Button("Dismiss") {
+                    dismissOverlay()
+                }
+                .padding(.top, 8)
+            }
+            .padding()
+            .onAppear {
+                // Automatically dismiss after 5 seconds.
+                DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+                    dismissOverlay()
+                }
+            }
+        }
+    }
+
+    private func dismissOverlay() {
+        guard isVisible else { return }
+        isVisible = false
+        dismiss()
+    }
+}
+
+#Preview {
+    TipOverlay(tip: "Focus on grip pressure", dismiss: {})
+        .background(Color.gray)
+}

--- a/Sources/PuttingGameCore/Analytics/AnalyticsLogger.swift
+++ b/Sources/PuttingGameCore/Analytics/AnalyticsLogger.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Simple analytics logger used to record lightweight events.
+/// In a real application this would send data to an analytics backend.
+@MainActor
+public final class AnalyticsLogger {
+    public static let shared = AnalyticsLogger()
+    private init() {}
+
+    /// Logs an analytics event to the console.
+    /// - Parameter event: Name of the event to log.
+    public func log(event: String) {
+        let timestamp = ISO8601DateFormatter().string(from: Date())
+        print("[Analytics] \(timestamp): \(event)")
+    }
+}

--- a/Sources/PuttingGameCore/PracticeSession.swift
+++ b/Sources/PuttingGameCore/PracticeSession.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Observation
+
+/// Represents a putting practice session, tracking consecutive misses
+/// for each distance and triggering tip overlays after repeated misses.
+@MainActor
+@Observable
+public final class PracticeSession {
+    /// Tip to display. When `nil` no tip is showing.
+    public private(set) var activeTip: String? = nil
+
+    /// Tracks consecutive misses keyed by distance.
+    private var consecutiveMisses: [Double: Int] = [:]
+
+    /// Tips to randomly display when the player struggles.
+    private let tips = [
+        "Focus on grip pressure",
+        "Check your aim line",
+        "Maintain a smooth tempo"
+    ]
+
+    public init() {}
+
+    /// Records the result of a putt.
+    /// - Parameters:
+    ///   - distance: Distance of the putt in feet.
+    ///   - made: Whether the putt was made.
+    public func recordPutt(distance: Double, made: Bool) {
+        if made {
+            // Reset miss streak for this distance.
+            consecutiveMisses[distance] = 0
+        } else {
+            let current = (consecutiveMisses[distance] ?? 0) + 1
+            consecutiveMisses[distance] = current
+            if current >= 3 {
+                triggerTip()
+                consecutiveMisses[distance] = 0
+            }
+        }
+    }
+
+    /// Dismisses the current tip overlay.
+    public func dismissTip() {
+        activeTip = nil
+    }
+
+    /// Triggers the tip overlay and logs analytics.
+    private func triggerTip() {
+        // Show a tip immediately to ensure <1s delay.
+        activeTip = tips.randomElement()
+        AnalyticsLogger.shared.log(event: "tip_shown")
+    }
+}


### PR DESCRIPTION
## Summary
- track consecutive misses per distance in practice sessions
- display a dismissible 5s tip after three misses and log `tip_shown`
- add simple analytics logger

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68ba057b1a94832b87d8c9a0b737b277