### PR TITLE
Expand badge system with categorized unlocks

### DIFF
--- a/Docs/badges.md
+++ b/Docs/badges.md
@@ -1,0 +1,35 @@
+# Badge Criteria
+
+This document describes the unlock requirements for gameplay badges.
+
+## Consistency
+- **firstMake** – Sink your first putt.
+- **tenMakes** – Make ten putts in a single session.
+- **noMiss** – Attempt at least ten putts and make them all.
+- **sessionMaster** – Make twenty‑five putts in one session.
+
+## Distance Mastery
+- **iceCold** – Make ten putts from 3 ft.
+- **smoothOperator** – Make ten putts from 5 ft.
+- **clutch** – Make five putts from 8 ft or more.
+- **ladderMaster** – Make at least one putt from 3, 5 and 8 ft with six total makes.
+- **longBomb** – Make three putts from 10 ft or more.
+
+## Break Mastery
+- **straightShooter** – Make ten straight putts.
+- **leftBreakTamer** – Make ten left‑break putts.
+- **rightBreakRuler** – Make ten right‑break putts.
+- **slopeConqueror** – Make five left‑break and five right‑break putts in a session.
+- **breakArtist** – Make at least one putt of each break type with nine total makes.
+
+## Streaks
+- **streakStarter** – Practice two days in a row.
+- **threeDayStreak** – Practice three days in a row.
+- **weekWarrior** – Practice seven days in a row.
+
+## Quests
+- **speedDemon** – Finish a ten‑shot session in five minutes or less.
+- **nightOwl** – Start a session at or after 9 PM.
+- **marathon** – Take fifty shots in a single session.
+
+`firstMake` can be earned in the very first session. With daily practice, `weekWarrior` unlocks within one week.

--- a/Sources/PuttingGameCore/BadgeManager.swift
+++ b/Sources/PuttingGameCore/BadgeManager.swift
@@ -3,19 +3,50 @@ import Foundation
 public struct BadgeManager {
     public init() {}
 
-    public func earnedBadges(forSession session: Session) -> [BadgeID] {
+    public func earnedBadges(forSession session: Session, profile: Profile) -> [BadgeID] {
         var earned: [BadgeID] = []
-        let makesByDistance = Dictionary(grouping: session.shots.filter { $0.result }, by: { $0.distanceFt })
-        if let shortMakes = makesByDistance[3], shortMakes.count >= 10 {
-            earned.append(.iceCold)
+        let makes = session.shots.filter { $0.result }
+
+        // Consistency
+        if !makes.isEmpty { earned.append(.firstMake) }
+        if makes.count >= 10 { earned.append(.tenMakes) }
+        if session.shots.count >= 10 && makes.count == session.shots.count { earned.append(.noMiss) }
+        if makes.count >= 25 { earned.append(.sessionMaster) }
+
+        // Distance Mastery
+        let makesByDistance = Dictionary(grouping: makes, by: { $0.distanceFt })
+        if let shortMakes = makesByDistance[3], shortMakes.count >= 10 { earned.append(.iceCold) }
+        if let midMakes = makesByDistance[5], midMakes.count >= 10 { earned.append(.smoothOperator) }
+        let longMakes = makes.filter { $0.distanceFt >= 8 && $0.distanceFt < 10 }
+        if longMakes.count >= 5 { earned.append(.clutch) }
+        let bombMakes = makes.filter { $0.distanceFt >= 10 }
+        if bombMakes.count >= 3 { earned.append(.longBomb) }
+        if [3,5,8].allSatisfy({ makesByDistance[$0]?.isEmpty == false }) && makes.count >= 6 { earned.append(.ladderMaster) }
+
+        // Break Mastery
+        let makesByBreak = Dictionary(grouping: makes, by: { $0.breakType })
+        if let straight = makesByBreak[.straight], straight.count >= 10 { earned.append(.straightShooter) }
+        if let left = makesByBreak[.left], left.count >= 10 { earned.append(.leftBreakTamer) }
+        if let right = makesByBreak[.right], right.count >= 10 { earned.append(.rightBreakRuler) }
+        if let left = makesByBreak[.left], let right = makesByBreak[.right], left.count >= 5 && right.count >= 5 {
+            earned.append(.slopeConqueror)
         }
-        if let longMakes = makesByDistance[8], longMakes.count >= 5 {
-            earned.append(.clutch)
+        if BreakType.allCases.allSatisfy({ makesByBreak[$0]?.isEmpty == false }) && makes.count >= 9 {
+            earned.append(.breakArtist)
         }
-        let ladderCounts = session.shots.filter { $0.result }.count
-        if ladderCounts >= 6 {
-            earned.append(.ladderMaster)
-        }
+
+        // Streaks
+        if profile.streakDays >= 2 { earned.append(.streakStarter) }
+        if profile.streakDays >= 3 { earned.append(.threeDayStreak) }
+        if profile.streakDays >= 7 { earned.append(.weekWarrior) }
+
+        // Quests
+        let duration = session.end.timeIntervalSince(session.start)
+        if session.shots.count >= 10 && duration <= 5 * 60 { earned.append(.speedDemon) }
+        let hour = Calendar.current.component(.hour, from: session.start)
+        if hour >= 21 { earned.append(.nightOwl) }
+        if session.shots.count >= 50 { earned.append(.marathon) }
+
         return earned
     }
 }

--- a/Sources/PuttingGameCore/Models.swift
+++ b/Sources/PuttingGameCore/Models.swift
@@ -66,5 +66,14 @@ public struct Profile: Codable, Sendable {
 }
 
 public enum BadgeID: String, Codable, Sendable, CaseIterable {
-    case iceCold, clutch, ladderMaster, speedDemon, consistency, leftBreakTamer
+    // Consistency
+    case firstMake, tenMakes, noMiss, sessionMaster
+    // Distance Mastery
+    case iceCold, smoothOperator, clutch, ladderMaster, longBomb
+    // Break Mastery
+    case straightShooter, leftBreakTamer, rightBreakRuler, slopeConqueror, breakArtist
+    // Streaks
+    case streakStarter, threeDayStreak, weekWarrior
+    // Quests
+    case speedDemon, nightOwl, marathon
 }

--- a/Tests/PuttingGameCoreTests/XPLevelTests.swift
+++ b/Tests/PuttingGameCoreTests/XPLevelTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import PuttingGameCore
 
@@ -19,11 +20,42 @@ struct XPLevelTests {
         #expect(xp == 110)
     }
 
-    @Test func badgesEarned() throws {
+    @Test func basicBadges() throws {
         var shots: [Shot] = []
-        for _ in 0..<10 { shots.append(Shot(distanceFt: 3, breakType: .straight, greenSpeed: .medium, result: true)) }
-        let session = Session(shots: shots)
-        let badges = BadgeManager().earnedBadges(forSession: session)
+        for _ in 0..<10 {
+            shots.append(Shot(distanceFt: 3, breakType: .straight, greenSpeed: .medium, result: true))
+        }
+        let start = Calendar.current.date(from: DateComponents(year: 2023, month: 1, day: 1, hour: 12))!
+        let end = start.addingTimeInterval(60)
+        let session = Session(start: start, end: end, shots: shots)
+        let profile = Profile()
+        let badges = BadgeManager().earnedBadges(forSession: session, profile: profile)
+        #expect(badges.contains(.firstMake))
+        #expect(badges.contains(.tenMakes))
         #expect(badges.contains(.iceCold))
+        #expect(badges.contains(.straightShooter))
+        #expect(badges.contains(.speedDemon))
+        #expect(!badges.contains(.nightOwl))
+    }
+
+    @Test func breakBadge() throws {
+        var shots: [Shot] = []
+        for _ in 0..<10 {
+            shots.append(Shot(distanceFt: 5, breakType: .left, greenSpeed: .medium, result: true))
+        }
+        let session = Session(shots: shots)
+        let profile = Profile()
+        let badges = BadgeManager().earnedBadges(forSession: session, profile: profile)
+        #expect(badges.contains(.leftBreakTamer))
+    }
+
+    @Test func streakBadges() throws {
+        let shots = [Shot(distanceFt: 3, breakType: .straight, greenSpeed: .medium, result: true)]
+        let session = Session(shots: shots)
+        let profile = Profile(streakDays: 3)
+        let badges = BadgeManager().earnedBadges(forSession: session, profile: profile)
+        #expect(badges.contains(.streakStarter))
+        #expect(badges.contains(.threeDayStreak))
+        #expect(!badges.contains(.weekWarrior))
     }
 }


### PR DESCRIPTION
## Summary
- Add ~20 badges spanning Consistency, Distance, Break, Streak, and Quest categories
- Track unlocks via updated `BadgeManager` and new `badges.md` design reference
- Expand unit tests covering badge unlock conditions

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68ba057e220c832b911fabec5337cff0