### PR TITLE
Add XP boundary and scaling tests

### DIFF
--- a/Tests/PuttingGameCoreTests/XPLevelTests.swift
+++ b/Tests/PuttingGameCoreTests/XPLevelTests.swift
@@ -19,6 +19,40 @@ struct XPLevelTests {
         #expect(xp == 110)
     }
 
+    @Test func xpForShotScalingAndMisses() throws {
+        let manager = XPManager()
+
+        // misses always grant zero XP
+        let miss = Shot(distanceFt: 15, breakType: .straight, greenSpeed: .medium, result: false)
+        #expect(manager.xpForShot(miss) == 0)
+
+        // linear scaling with distance for made putts
+        let ten = Shot(distanceFt: 10, breakType: .straight, greenSpeed: .medium, result: true)
+        let twenty = Shot(distanceFt: 20, breakType: .straight, greenSpeed: .medium, result: true)
+        #expect(manager.xpForShot(ten) == 100)
+        #expect(manager.xpForShot(twenty) == 200)
+        #expect(manager.xpForShot(twenty) == 2 * manager.xpForShot(ten))
+
+        // boundary: zero distance
+        let zero = Shot(distanceFt: 0, breakType: .straight, greenSpeed: .medium, result: true)
+        #expect(manager.xpForShot(zero) == 0)
+
+        // boundary: unusually large distance
+        let huge = Shot(distanceFt: 1000, breakType: .straight, greenSpeed: .medium, result: true)
+        #expect(manager.xpForShot(huge) == 10000)
+    }
+
+    @Test func totalXPBoundaryCases() throws {
+        let shots = [
+            Shot(distanceFt: 3, breakType: .straight, greenSpeed: .medium, result: true),   // 30
+            Shot(distanceFt: 0, breakType: .left, greenSpeed: .slow, result: true),         // 0
+            Shot(distanceFt: 20, breakType: .right, greenSpeed: .fast, result: false),      // 0
+            Shot(distanceFt: 1000, breakType: .straight, greenSpeed: .medium, result: true) // 10000
+        ]
+        let session = Session(shots: shots)
+        #expect(XPManager().totalXP(forSession: session) == 10030)
+    }
+
     @Test func badgesEarned() throws {
         var shots: [Shot] = []
         for _ in 0..<10 { shots.append(Shot(distanceFt: 3, breakType: .straight, greenSpeed: .medium, result: true)) }


### PR DESCRIPTION
## Summary
- Extend XP tests for misses and distance scaling
- Cover zero-distance and large shot boundaries
- Validate total session XP with varied results

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68ba064ebb04832b9571e0faa2e74be6