### PR TITLE
Add basic shot logging and quest UI

### DIFF
--- a/Sources/PuttingGameCore/FX/ConfettiEmitter.swift
+++ b/Sources/PuttingGameCore/FX/ConfettiEmitter.swift
@@ -1,3 +1,4 @@
+#if canImport(SpriteKit)
 import SpriteKit
 
 /// A reusable confetti effect backed by up to three `SKEmitterNode` instances.
@@ -46,5 +47,6 @@ public final class ConfettiEmitter: SKNode {
     public func stop() {
         emitters.forEach { $0.particleBirthRate = 0 }
     }
-}
+  }
+#endif
 

--- a/Sources/PuttingGameCore/FX/FXTuning.swift
+++ b/Sources/PuttingGameCore/FX/FXTuning.swift
@@ -1,3 +1,4 @@
+#if canImport(CoreGraphics)
 import CoreGraphics
 
 /// Central tuning table for in-game visual effects.
@@ -29,5 +30,6 @@ public enum FXTuning {
 
     /// Current tuning values for the confetti effect.
     public static var confetti = Confetti.default
-}
+  }
+#endif
 

--- a/Sources/PuttingGameCore/QuestView.swift
+++ b/Sources/PuttingGameCore/QuestView.swift
@@ -5,20 +5,37 @@ public struct QuestView: View {
     @ObservedObject var manager: QuestManager
     @State private var now: Date = .now
     private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
+    private let onReward: (Int) -> Void
 
-    public init(manager: QuestManager) {
+    public init(manager: QuestManager, onReward: @escaping (Int) -> Void = { _ in }) {
         self.manager = manager
+        self.onReward = onReward
     }
 
     public var body: some View {
         List {
             ForEach(manager.quests) { quest in
-                VStack(alignment: .leading) {
+                VStack(alignment: .leading, spacing: 4) {
                     Text(quest.title)
                     Text("Progress: \(quest.progress)/\(quest.goal)")
                         .font(.subheadline)
                     Text(timeRemaining(for: quest))
                         .font(.caption)
+                    if quest.isComplete {
+                        if quest.claimed {
+                            Text("Reward claimed")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        } else {
+                            Button("Claim \(quest.reward) XP") {
+                                if let reward = manager.claimReward(for: quest.id) {
+                                    onReward(reward)
+                                }
+                            }
+                            .buttonStyle(.borderedProminent)
+                            .padding(.top, 4)
+                        }
+                    }
                 }
             }
         }
@@ -31,7 +48,7 @@ public struct QuestView: View {
         let formatter = DateComponentsFormatter()
         formatter.allowedUnits = [.hour, .minute, .second]
         formatter.unitsStyle = .short
-        return formatter.string(from: remaining) ?? "" 
+        return formatter.string(from: remaining) ?? ""
     }
 }
 #endif


### PR DESCRIPTION
## Summary
- add simple shot logging interface with profile, XP, and quest links
- enable claiming quest rewards
- conditionally build SpriteKit and CoreGraphics FX code

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68bdf5098590832bb1576fc8b5a53dd5