### PR TITLE
Fix concurrency safety for confetti tuning

### DIFF
--- a/Sources/PuttingGameCore/FX/FXTuning.swift
+++ b/Sources/PuttingGameCore/FX/FXTuning.swift
@@ -4,7 +4,7 @@ import CoreGraphics
 /// Central tuning table for in-game visual effects.
 public enum FXTuning {
     /// Tunable parameters for the confetti emitter.
-    public struct Confetti {
+    public struct Confetti: Sendable {
         /// Desired number of emitter nodes. The implementation caps this at three.
         public var nodeCount: Int
         /// Maximum number of particles emitted per node.
@@ -29,7 +29,7 @@ public enum FXTuning {
     }
 
     /// Current tuning values for the confetti effect.
-    public static var confetti = Confetti.default
+    @MainActor public static var confetti = Confetti.default
   }
 #endif
 


### PR DESCRIPTION
## Summary
- mark FXTuning.Confetti as `Sendable`
- restrict global confetti tuning to the main actor

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68bdf9b2b534832bae3008c6b969497c