### PR TITLE
Refine confetti tuning concurrency isolation

### DIFF
--- a/Sources/PuttingGameCore/FX/ConfettiEmitter.swift
+++ b/Sources/PuttingGameCore/FX/ConfettiEmitter.swift
@@ -1,7 +1,9 @@
 #if canImport(SpriteKit)
-import SpriteKit
+@preconcurrency import SpriteKit
+@preconcurrency import CoreGraphics
 
 /// A reusable confetti effect backed by up to three `SKEmitterNode` instances.
+@MainActor
 public final class ConfettiEmitter: SKNode {
     private let tuning: FXTuning.Confetti
     private var emitters: [SKEmitterNode] = []
@@ -47,6 +49,6 @@ public final class ConfettiEmitter: SKNode {
     public func stop() {
         emitters.forEach { $0.particleBirthRate = 0 }
     }
-  }
+}
 #endif
 

--- a/Sources/PuttingGameCore/FX/FXTuning.swift
+++ b/Sources/PuttingGameCore/FX/FXTuning.swift
@@ -1,10 +1,10 @@
 #if canImport(CoreGraphics)
-import CoreGraphics
+@preconcurrency import CoreGraphics
 
 /// Central tuning table for in-game visual effects.
 public enum FXTuning {
     /// Tunable parameters for the confetti emitter.
-    public struct Confetti {
+    public struct Confetti: Sendable {
         /// Desired number of emitter nodes. The implementation caps this at three.
         public var nodeCount: Int
         /// Maximum number of particles emitted per node.
@@ -29,7 +29,7 @@ public enum FXTuning {
     }
 
     /// Current tuning values for the confetti effect.
-    public static var confetti = Confetti.default
-  }
+    @MainActor public static var confetti: Confetti = .default
+}
 #endif
 


### PR DESCRIPTION
## Summary
- treat CoreGraphics and SpriteKit imports as preconcurrency and isolate the confetti emitter on the main actor
- expose global confetti tuning via a `Sendable` struct and a main-actor stored property
- normalize preprocessor directives

## Testing
- `swift build -Xswiftc -strict-concurrency=complete`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68bdf9b2b534832bae3008c6b969497c