### PR TITLE
Filter quest progress by shot criteria

### DIFF
--- a/PuttingGameV1/ContentView.swift
+++ b/PuttingGameV1/ContentView.swift
@@ -81,9 +81,7 @@ struct ContentView: View {
         profile.xp += gain
         profile.level = levelManager.level(forXP: profile.xp)
         if made {
-            questManager.quests.forEach { quest in
-                questManager.updateProgress(for: quest.id)
-            }
+            questManager.record(shot: shot)
         }
         made = false
     }

--- a/Tests/PuttingGameCoreTests/QuestManagerTests.swift
+++ b/Tests/PuttingGameCoreTests/QuestManagerTests.swift
@@ -26,4 +26,19 @@ struct QuestManagerTests {
         #expect(newDailyIDs.intersection(previousDailyIDs).isEmpty)
         #expect(manager.quests.first { $0.frequency == .weekly }!.id == weeklyID)
     }
+
+    @Test func progressOnlyMatchingQuest() throws {
+        let defaults = UserDefaults(suiteName: "QuestManagerTests3")!
+        defaults.removePersistentDomain(forName: "QuestManagerTests3")
+        let manager = QuestManager(userDefaults: defaults)
+        let now = Date()
+        let end = now.addingTimeInterval(60)
+        let q1 = Quest(frequency: .daily, title: "3ft", start: now, end: end, goal: 1, reward: 10, requiredDistance: 3)
+        let q2 = Quest(frequency: .daily, title: "5ft", start: now, end: end, goal: 1, reward: 10, requiredDistance: 5)
+        manager.replaceQuests([q1, q2])
+        let shot = Shot(distanceFt: 3, breakType: .straight, greenSpeed: .medium, result: true)
+        manager.record(shot: shot)
+        #expect(manager.quests.first { $0.id == q1.id }!.progress == 1)
+        #expect(manager.quests.first { $0.id == q2.id }!.progress == 0)
+    }
 }


### PR DESCRIPTION
## Summary
- track distance and break requirements on Quest
- update QuestManager to record shot progress only when it matches quest requirements
- add regression test for quest progress filtering

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68bedb363c40832bb92166a5a10830f7