### PR TITLE
Isolate QuestManager on main thread

### DIFF
--- a/PuttingGameV1/ContentView.swift
+++ b/PuttingGameV1/ContentView.swift
@@ -81,9 +81,7 @@ struct ContentView: View {
         profile.xp += gain
         profile.level = levelManager.level(forXP: profile.xp)
         if made {
-            questManager.quests.forEach { quest in
-                questManager.updateProgress(for: quest.id)
-            }
+            questManager.record(shot: shot)
         }
         made = false
     }

--- a/Sources/PuttingGameCore/QuestManager.swift
+++ b/Sources/PuttingGameCore/QuestManager.swift
@@ -59,7 +59,7 @@ public protocol QuestManagerBase: AnyObject {}
 #endif
 
 @MainActor
-public final class QuestManager: QuestManagerBase {
+public final class QuestManager: QuestManagerBase, @unchecked Sendable {
     private let storageKey = "QuestManager.quests"
     private let userDefaults: UserDefaults
 

--- a/Sources/PuttingGameCore/QuestManager.swift
+++ b/Sources/PuttingGameCore/QuestManager.swift
@@ -59,7 +59,7 @@ public protocol QuestManagerBase: AnyObject {}
 #endif
 
 @MainActor
-public final class QuestManager: QuestManagerBase, @unchecked Sendable {
+public final class QuestManager: QuestManagerBase {
     private let storageKey = "QuestManager.quests"
     private let userDefaults: UserDefaults
 

--- a/Sources/PuttingGameCore/QuestManager.swift
+++ b/Sources/PuttingGameCore/QuestManager.swift
@@ -14,6 +14,8 @@ public struct Quest: Codable, Identifiable, Equatable {
     public var goal: Int
     public var reward: Int
     public var claimed: Bool
+    public var requiredDistance: Int?
+    public var requiredBreak: BreakType?
 
     public init(id: String = UUID().uuidString,
                 frequency: Frequency,
@@ -23,7 +25,9 @@ public struct Quest: Codable, Identifiable, Equatable {
                 progress: Int = 0,
                 goal: Int,
                 reward: Int,
-                claimed: Bool = false) {
+                claimed: Bool = false,
+                requiredDistance: Int? = nil,
+                requiredBreak: BreakType? = nil) {
         self.id = id
         self.frequency = frequency
         self.title = title
@@ -33,10 +37,18 @@ public struct Quest: Codable, Identifiable, Equatable {
         self.goal = goal
         self.reward = reward
         self.claimed = claimed
+        self.requiredDistance = requiredDistance
+        self.requiredBreak = requiredBreak
     }
 
     public var isComplete: Bool { progress >= goal }
     public var timeRemaining: TimeInterval { end.timeIntervalSinceNow }
+
+    public func matches(_ shot: Shot) -> Bool {
+        if let dist = requiredDistance, shot.distanceFt != dist { return false }
+        if let brk = requiredBreak, shot.breakType != brk { return false }
+        return true
+    }
 }
 
 // Protocol to allow conditional ObservableObject conformance
@@ -46,6 +58,7 @@ public protocol QuestManagerBase: ObservableObject {}
 public protocol QuestManagerBase: AnyObject {}
 #endif
 
+@MainActor
 public final class QuestManager: QuestManagerBase {
     private let storageKey = "QuestManager.quests"
     private let userDefaults: UserDefaults
@@ -74,9 +87,18 @@ public final class QuestManager: QuestManagerBase {
         save()
     }
 
-    public func updateProgress(for questID: String, by amount: Int = 1) {
-        guard let idx = quests.firstIndex(where: { $0.id == questID }) else { return }
-        quests[idx].progress = min(quests[idx].progress + amount, quests[idx].goal)
+    public func record(shot: Shot) {
+        guard shot.result else { return }
+        for idx in quests.indices {
+            if quests[idx].matches(shot) {
+                quests[idx].progress = min(quests[idx].progress + 1, quests[idx].goal)
+            }
+        }
+        save()
+    }
+
+    public func replaceQuests(_ newQuests: [Quest]) {
+        quests = newQuests
         save()
     }
 

--- a/Tests/PuttingGameCoreTests/QuestManagerTests.swift
+++ b/Tests/PuttingGameCoreTests/QuestManagerTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Testing
 @testable import PuttingGameCore
 
+@MainActor
 struct QuestManagerTests {
     @Test func generatesQuests() throws {
         let defaults = UserDefaults(suiteName: "QuestManagerTests")!
@@ -25,5 +26,36 @@ struct QuestManagerTests {
         #expect(newDailyIDs.count == 3)
         #expect(newDailyIDs.intersection(previousDailyIDs).isEmpty)
         #expect(manager.quests.first { $0.frequency == .weekly }!.id == weeklyID)
+    }
+
+    @Test func progressOnlyMatchingQuest() throws {
+        let defaults = UserDefaults(suiteName: "QuestManagerTests3")!
+        defaults.removePersistentDomain(forName: "QuestManagerTests3")
+        let manager = QuestManager(userDefaults: defaults)
+        let now = Date()
+        let end = now.addingTimeInterval(60)
+        let q1 = Quest(frequency: .daily, title: "3ft", start: now, end: end, goal: 1, reward: 10, requiredDistance: 3)
+        let q2 = Quest(frequency: .daily, title: "5ft", start: now, end: end, goal: 1, reward: 10, requiredDistance: 5)
+        manager.replaceQuests([q1, q2])
+        let shot = Shot(distanceFt: 3, breakType: .straight, greenSpeed: .medium, result: true)
+        manager.record(shot: shot)
+        #expect(manager.quests.first { $0.id == q1.id }!.progress == 1)
+        #expect(manager.quests.first { $0.id == q2.id }!.progress == 0)
+    }
+
+    @Test func concurrentRecordsAreSerialized() async throws {
+        let defaults = UserDefaults(suiteName: "QuestManagerTests4")!
+        defaults.removePersistentDomain(forName: "QuestManagerTests4")
+        let manager = QuestManager(userDefaults: defaults)
+        let now = Date()
+        let end = now.addingTimeInterval(60)
+        let quest = Quest(frequency: .daily, title: "3ft", start: now, end: end, goal: 100, reward: 10, requiredDistance: 3)
+        manager.replaceQuests([quest])
+        let shot = Shot(distanceFt: 3, breakType: .straight, greenSpeed: .medium, result: true)
+        let tasks = (0..<100).map { _ in
+            Task.detached { await manager.record(shot: shot) }
+        }
+        for task in tasks { await task.value }
+        #expect(manager.quests.first?.progress == 100)
     }
 }

--- a/Tests/PuttingGameCoreTests/QuestManagerTests.swift
+++ b/Tests/PuttingGameCoreTests/QuestManagerTests.swift
@@ -52,10 +52,11 @@ struct QuestManagerTests {
         let quest = Quest(frequency: .daily, title: "3ft", start: now, end: end, goal: 100, reward: 10, requiredDistance: 3)
         manager.replaceQuests([quest])
         let shot = Shot(distanceFt: 3, breakType: .straight, greenSpeed: .medium, result: true)
-        let tasks = (0..<100).map { _ in
-            Task.detached { await manager.record(shot: shot) }
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<100 {
+                group.addTask { await manager.record(shot: shot) }
+            }
         }
-        for task in tasks { await task.value }
         #expect(manager.quests.first?.progress == 100)
     }
 }

--- a/Tests/PuttingGameCoreTests/QuestManagerTests.swift
+++ b/Tests/PuttingGameCoreTests/QuestManagerTests.swift
@@ -52,11 +52,14 @@ struct QuestManagerTests {
         let quest = Quest(frequency: .daily, title: "3ft", start: now, end: end, goal: 100, reward: 10, requiredDistance: 3)
         manager.replaceQuests([quest])
         let shot = Shot(distanceFt: 3, breakType: .straight, greenSpeed: .medium, result: true)
-        await withTaskGroup(of: Void.self) { group in
-            for _ in 0..<100 {
-                group.addTask { await manager.record(shot: shot) }
+        let task = Task.detached {
+            await withTaskGroup(of: Void.self) { group in
+                for _ in 0..<100 {
+                    group.addTask { await manager.record(shot: shot) }
+                }
             }
         }
+        await task.value
         #expect(manager.quests.first?.progress == 100)
     }
 }


### PR DESCRIPTION
## Summary
- mark `QuestManager` as `@MainActor` to serialize quest mutations
- cover concurrent shot recording with a regression test
- run quest tests on the main actor for thread-safe access

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68bedb363c40832bb92166a5a10830f7