### PR TITLE
Sort insight engine stats for consistent recommendations

### DIFF
--- a/Sources/PuttingGameCore/InsightEngine.swift
+++ b/Sources/PuttingGameCore/InsightEngine.swift
@@ -21,12 +21,19 @@ public struct InsightEngine {
             stats.append((distance, attempts, accuracy))
         }
         guard !stats.isEmpty else { return .none }
+        // sort stats by accuracy (lowest first) with distance as tiebreaker
+        let sortedStats = stats.sorted { lhs, rhs in
+            if lhs.accuracy == rhs.accuracy {
+                return lhs.distance < rhs.distance
+            }
+            return lhs.accuracy < rhs.accuracy
+        }
         // determine 25th percentile accuracy
-        let accuracies = stats.map { $0.accuracy }.sorted()
+        let accuracies = sortedStats.map { $0.accuracy }
         let idx = Int(Double(accuracies.count - 1) * 0.25)
         let threshold = accuracies[idx]
-        // find first distance with accuracy <= threshold
-        if let target = stats.first(where: { $0.accuracy <= threshold }) {
+        // pick the first distance within the bottom quartile
+        if let target = sortedStats.first(where: { $0.accuracy <= threshold }) {
             return .ladder(distance: target.distance)
         }
         return .none

--- a/Tests/PuttingGameCoreTests/InsightEngineTests.swift
+++ b/Tests/PuttingGameCoreTests/InsightEngineTests.swift
@@ -45,4 +45,22 @@ struct InsightEngineTests {
             Issue.record("Expected a ladder insight")
         }
     }
+
+    // Ensure that insertion order of shots does not affect the insight recommendation
+    @Test func ladderRecommendationOrderIndependence() throws {
+        var shots: [Shot] = []
+        // append in mixed order to mimic random session logs
+        for i in 0..<20 {
+            shots.append(Shot(distanceFt: 7, breakType: .straight, greenSpeed: .medium, result: i < 10))
+        }
+        for i in 0..<20 {
+            shots.append(Shot(distanceFt: 3, breakType: .straight, greenSpeed: .medium, result: i < 15))
+        }
+        for i in 0..<20 {
+            shots.append(Shot(distanceFt: 5, breakType: .straight, greenSpeed: .medium, result: i < 5))
+        }
+        let session = Session(shots: shots)
+        let engine = InsightEngine()
+        #expect(engine.insight(for: session) == .ladder(distance: 5))
+    }
 }


### PR DESCRIPTION
## Summary
- Ensure InsightEngine sorts distance stats by accuracy and distance before computing 25th percentile to avoid order-dependent ladder tips
- Add unit test confirming ladder recommendation is stable regardless of shot insertion order

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68c2074a6f54832bbb0706c6824b40a3