### PR TITLE
Add session statistics utilities

### DIFF
--- a/Sources/PuttingGameCore/SessionStats.swift
+++ b/Sources/PuttingGameCore/SessionStats.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public struct SessionStats: Equatable {
+    public let totalShots: Int
+    public let makes: Int
+    public let makePercentage: Double
+    public let averageMakeDistance: Double
+
+    public init(totalShots: Int, makes: Int, makePercentage: Double, averageMakeDistance: Double) {
+        self.totalShots = totalShots
+        self.makes = makes
+        self.makePercentage = makePercentage
+        self.averageMakeDistance = averageMakeDistance
+    }
+}
+
+public extension Session {
+    var stats: SessionStats {
+        let total = shots.count
+        let madeShots = shots.filter { $0.result }
+        let makes = madeShots.count
+        let makePercentage = total > 0 ? Double(makes) / Double(total) : 0
+        let averageMakeDistance = makes > 0 ? Double(madeShots.reduce(0) { $0 + $1.distanceFt }) / Double(makes) : 0
+        return SessionStats(totalShots: total, makes: makes, makePercentage: makePercentage, averageMakeDistance: averageMakeDistance)
+    }
+}
+

--- a/Tests/PuttingGameCoreTests/SessionStatsTests.swift
+++ b/Tests/PuttingGameCoreTests/SessionStatsTests.swift
@@ -1,0 +1,28 @@
+import Testing
+@testable import PuttingGameCore
+
+struct SessionStatsTests {
+    @Test func computesBasicStats() throws {
+        let shots = [
+            Shot(distanceFt: 3, breakType: .straight, greenSpeed: .medium, result: true),
+            Shot(distanceFt: 5, breakType: .left, greenSpeed: .medium, result: false),
+            Shot(distanceFt: 8, breakType: .right, greenSpeed: .fast, result: true)
+        ]
+        let session = Session(shots: shots)
+        let stats = session.stats
+        #expect(stats.totalShots == 3)
+        #expect(stats.makes == 2)
+        #expect(abs(stats.makePercentage - 2.0/3.0) < 0.0001)
+        #expect(abs(stats.averageMakeDistance - 5.5) < 0.0001)
+    }
+
+    @Test func emptySessionStats() throws {
+        let session = Session()
+        let stats = session.stats
+        #expect(stats.totalShots == 0)
+        #expect(stats.makes == 0)
+        #expect(stats.makePercentage == 0)
+        #expect(stats.averageMakeDistance == 0)
+    }
+}
+


### PR DESCRIPTION
## Summary
- compute session summary metrics like make percentage and average make distance
- cover new statistics with unit tests

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68c208596860832bab6bb5ab138efe9d