### PR TITLE
Fix Theme concurrency and remove Equatable

### DIFF
--- a/Sources/PuttingGameCore/Theme.swift
+++ b/Sources/PuttingGameCore/Theme.swift
@@ -1,27 +1,43 @@
 #if canImport(SwiftUI)
 import SwiftUI
 
-public struct Theme: Equatable {
+/// A collection of styling information used throughout the application.
+///
+/// The type previously attempted to conform to `Equatable`, but `LinearGradient`
+/// from SwiftUI does not offer `Equatable` conformance. Since equality checks
+/// for complete themes are not required anywhere in the package, the explicit
+/// conformance has been removed.
+public struct Theme {
+    /// Colors used by the theme.
     public struct Colors {
         public let background: Color
         public let foreground: Color
         public let accent: Color
         public let text: Color
     }
+
+    /// Standard corner radii used throughout the UI.
     public struct Radii {
         public let small: CGFloat
         public let medium: CGFloat
         public let large: CGFloat
     }
+
+    /// Information for a single shadow instance.
     public struct Shadow {
         public let color: Color
         public let radius: CGFloat
         public let x: CGFloat
         public let y: CGFloat
     }
+
+    /// Collection of shadows used by the theme.
     public struct Shadows {
         public let standard: Shadow
     }
+
+    /// Linear gradients used by the theme. `LinearGradient` does not conform to
+    /// `Sendable`, so we adopt unchecked sendable conformance below.
     public struct Gradients {
         public let background: LinearGradient
     }
@@ -32,6 +48,19 @@ public struct Theme: Equatable {
     public let gradients: Gradients
 }
 
+// MARK: - Concurrency
+
+// SwiftUI types such as `Color` and `LinearGradient` do not currently conform to
+// `Sendable`. The theme model is immutable and only contains value types, so we
+// can safely mark it and its nested types as unchecked `Sendable` to satisfy
+// Swift 6's stricter concurrency checking.
+extension Theme: @unchecked Sendable {}
+extension Theme.Colors: @unchecked Sendable {}
+extension Theme.Radii: Sendable {}
+extension Theme.Shadow: @unchecked Sendable {}
+extension Theme.Shadows: @unchecked Sendable {}
+extension Theme.Gradients: @unchecked Sendable {}
+
 public enum ThemeKind: String, CaseIterable, Identifiable {
     case classic = "Classic"
     case midnight = "Midnight"
@@ -39,7 +68,7 @@ public enum ThemeKind: String, CaseIterable, Identifiable {
     public var id: String { rawValue }
 }
 
-public extension Theme {
+@MainActor public extension Theme {
     static let classic = Theme(
         colors: .init(
             background: Color(red: 0xFA/255, green: 0xF9/255, blue: 0xF6/255),


### PR DESCRIPTION
## Summary
- remove unused Equatable conformance from `Theme`
- mark Theme and related structs as `@unchecked Sendable` to satisfy Swift 6 concurrency checks
- isolate static Theme presets on the main actor

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68c208e5d390832b818010bcf2ccab0b